### PR TITLE
Updated rule: no-console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 9.4.0 (2019-02-05)
+- ESLint 5.13.0
+- Update rule `['warn', { allow: ['warn', 'error'] }]`
+
 ## 9.3.0 (2019-02-05)
 - ESLint 5.13.0
 - Add rule `'no-useless-catch': 'error'`.

--- a/config/defaults.js
+++ b/config/defaults.js
@@ -10,7 +10,9 @@ module.exports = {
 		'no-await-in-loop': 'error',
 		'no-compare-neg-zero': 'error',
 		'no-cond-assign': 'error',
-		'no-console': 'warn',
+		'no-console': ['warn', {
+			allow: ['warn', 'error'],
+		}],
 		'no-constant-condition': 'error',
 		'no-control-regex': 'error',
 		'no-debugger': 'warn',


### PR DESCRIPTION
`console.warn()`  and `console.error()` are now allowed to be used.

closes #48 